### PR TITLE
[sc-139630][sc-138862]:Update to android 1.6.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -97,7 +97,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.movableink.sdk:inked:1.6.0"
+  implementation "com.movableink.sdk:inked:1.6.1"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movable/react-native-sdk",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "MovableInk React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
update android version to 1.6.1 fixes :
[sc-13963](https://app.shortcut.com/movableink/story/139630/vueling-sdk-crashes-android)
[sc-138862](https://app.shortcut.com/movableink/story/138862/android-error-when-surfacing-in-app-messages-using-sdk)