### PR TITLE
React Native Release 3.0.0 [sc-189860]

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -122,7 +122,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.movableink.sdk:inked:2.3.0"
+  implementation "com.movableink.sdk:inked:3.0.0"
   implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movable/react-native-sdk",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "MovableInk React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-movable-ink.podspec
+++ b/react-native-movable-ink.podspec
@@ -17,10 +17,10 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   # Enable when testing local pod
-  s.dependency "MovableInk"
+  #s.dependency "MovableInk"
 
   # Disable when testing local pod
-  # s.dependency "MovableInk", "2.3.0"
+  s.dependency "MovableInk", "3.0.0"
 
   s.dependency "React-Core"
 


### PR DESCRIPTION
This pull request updates the Movable Ink SDK to version 3.0.0 across the Android, iOS, and JavaScript packages, ensuring consistency and access to the latest features and fixes. It also updates the package version to reflect this major upgrade.

**SDK Version Upgrades:**

* Updated the Android dependency for `com.movableink.sdk:inked` from `2.3.0` to `3.0.0` in `android/build.gradle`.
* Updated the iOS CocoaPods dependency for `MovableInk` from `2.3.0` to `3.0.0` in `react-native-movable-ink.podspec`.

**Package Version Update:**

* Bumped the package version from `2.2.0` to `3.0.0` in `package.json` to reflect the major SDK upgrade.

## Native SDKs must be released before this is released